### PR TITLE
Show full build name instead of full project name

### DIFF
--- a/src/main/resources/org/zeroturnaround/jenkins/flowbuildtestaggregator/FlowTestResults/index.jelly
+++ b/src/main/resources/org/zeroturnaround/jenkins/flowbuildtestaggregator/FlowTestResults/index.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
         <j:forEach var="report" items="${it.childReports}">
           <tr>
             <td class="pane">
-              <a href="${rootURL}/${report.child.url}testReport">${report.child.project.fullDisplayName}</a>
+              <a href="${rootURL}/${report.child.url}testReport">${report.child.fullDisplayName}</a>
             </td>
             <td data="${report.result.duration}" class="pane" style="text-align:right">
               ${report.result.durationString}


### PR DESCRIPTION
Fix for issue #7. Just display the build's full display name, which should include both the job name as well as build ID.