### PR TITLE
Support for aggregating results from triggered flow and multijob builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
       <artifactId>build-flow-plugin</artifactId>
       <version>0.12</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jenkins-multijob-plugin</artifactId>
+      <version>1.16</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Flow:
Only results from top-level jobs were gathered, this recursive function brings the support to be able to aggregate the results from the triggered flow jobs.

Multijob:
Multijobs can be triggered from the flow job and we would like to collect the results from all the jobs.

When the multijob is invoked from the flow, results are collected from 2 places:
* multijob parent - extra results can be present (ideally should not clone the results stored at downstream builds)
* multijob subbuilds