### PR TITLE
Fixes #15 Ignore missing reports

### DIFF
--- a/src/main/java/org/zeroturnaround/jenkins/flowbuildtestaggregator/FlowTestResults.java
+++ b/src/main/java/org/zeroturnaround/jenkins/flowbuildtestaggregator/FlowTestResults.java
@@ -19,7 +19,13 @@ public class FlowTestResults extends AggregatedTestResultAction {
 
   @Override
   public AbstractBuild<?, ?> resolveChild(Child child) {
-    return Jenkins.getInstance().getItemByFullName(child.name, AbstractProject.class).getBuildByNumber(child.build);
+    AbstractProject<?, ?> project = Jenkins.getInstance().getItemByFullName(child.name, AbstractProject.class);
+
+    if (project != null) {
+      return project.getBuildByNumber(child.build);
+    } else {
+      return null;
+    }
   }
 
   @Override


### PR DESCRIPTION
When a job in an aggregated report cannot be found (i.e. deleted or renamed) we should ignore that test report and display the aggregated report for all the reports which are accessible. 
